### PR TITLE
v34b: target_rms_db=-48 (calibrate gain-aug peak to device level)

### DIFF
--- a/docs/ML_IMPROVEMENT_PLAN.md
+++ b/docs/ML_IMPROVEMENT_PLAN.md
@@ -729,6 +729,36 @@ Single-axis change vs v33. Architecture, labels, n_mels, fmin/fmax, loss, optimi
 
 If v34 succeeds: that's the new deployed model. If v34 plateaus or regresses: input-side hypothesis is wrong, return to investigating the saturated activation at the source (training itself produces saturated outputs vs the data — a curriculum/loss issue).
 
+### v34 result + correction (2026-04-28)
+
+**v34 plateaued at val_peak_F1 = 0.627** (vs v33's 0.690), early-stopped at epoch 16. Best peak_F1 was epoch 1 (0.627), no improvement across all 16 epochs. Frame F1 still climbed (0.482 → 0.534) — pattern consistent with saturation: model learns to predict "high mel = onset-likely" on average (frame F1 up) but loses temporal contrast (peak F1 flat).
+
+**Correction to the v34 plan above:** the claim "v33 dropped gain aug, v34 restored it" was WRONG. Both v33 and v34 ran with `--augment` (Makefile default), both applied the same hardcoded `[-18, -12, -6, +6, +12, +18]` dB gain augmentation. The only substantive config diff was `target_rms_db: -72 → -30`.
+
+**Real cause:** interaction between `target_rms_db` and gain augmentation. At v34's `-30 + +18 dB = -12 dBFS` effective, the loudest training variant lands above device runtime (~-15 dBFS) and saturates bass mel bands. v33's `-72 + +18 dB = -54 dBFS` was well below saturation. Same gain aug, different baseline — different result.
+
+**Mel mean per config (measured):**
+- v33 prepped data: ~0.37 (bimodal: clean+aug-quiet around 0.10, conditioned around 0.75)
+- v34 prepped data: 0.808 (unimodal+saturated; +18 aug variant clips at 1.0)
+- Device runtime: 0.754
+
+v33's bimodal training distribution included device-like levels via the conditioned variant (compressor + whitening). It worked offline (val_peak_F1=0.690) and at degraded-but-functional on-device F1=0.570. v34 collapsed both modes into one centered too high, with the +18 dB aug pushing into saturation.
+
+### v34b plan (2026-04-28)
+
+Single-axis change vs v33: `target_rms_db: -72 → -48`. Calibrates the gain-aug *peak* to device level instead of the *center*:
+- target_rms_db + 18 = -30 dBFS (device level) → target_rms_db = -48
+- Clean variant: -48 dBFS, mel mean ~0.20
+- Gain aug peak: -30 dBFS, mel mean ~0.50 (no saturation)
+- Conditioned variant: lands near device level via compressor+whitening (mel ~0.7-0.8)
+
+This sits between v33 (-72) and v34 (-30) and tests whether the calibration direction is right when saturation is avoided. If v34b also plateaus around 0.62, the calibration hypothesis is wrong and we revert to v33-as-deployed and approach from a different angle.
+
+**Falsifiable predictions for v34b on edm/:**
+- val_peak_F1 ≥ 0.66 (between v33's 0.69 and v34's 0.63)
+- on-device F1 ≥ v33's 0.570 (acceptance bar)
+- Activation distribution mean ≤ 0.40 (vs v34 at 0.45)
+
 ### Tool fixes landed 2026-04-23
 
 - `prepare_dataset.py --exclude-dir` → `action='append'`: previously silently kept only the last value; now unions stems from all passed dirs.

--- a/docs/ML_IMPROVEMENT_PLAN.md
+++ b/docs/ML_IMPROVEMENT_PLAN.md
@@ -735,29 +735,31 @@ If v34 succeeds: that's the new deployed model. If v34 plateaus or regresses: in
 
 **Correction to the v34 plan above:** the claim "v33 dropped gain aug, v34 restored it" was WRONG. Both v33 and v34 ran with `--augment` (Makefile default), both applied the same hardcoded `[-18, -12, -6, +6, +12, +18]` dB gain augmentation. The only substantive config diff was `target_rms_db: -72 → -30`.
 
-**Real cause:** interaction between `target_rms_db` and gain augmentation. At v34's `-30 + +18 dB = -12 dBFS` effective, the loudest training variant lands above device runtime (~-15 dBFS) and saturates bass mel bands. v33's `-72 + +18 dB = -54 dBFS` was well below saturation. Same gain aug, different baseline — different result.
+**Real cause:** interaction between `target_rms_db` and gain augmentation. At v34's `-30 + +18 dB = -12 dBFS RMS` effective, the loudest training variant lands above device runtime (~-15 dBFS RMS) and drives instantaneous peaks into clipping/saturation, saturating bass mel bands. v33's `-72 + +18 dB = -54 dBFS RMS` was well below saturation. Same gain aug, different RMS baseline — different result. (`target_rms_db` calibrates RMS, not peak; high-crest signals like drum transients can still clip near 0 dBFS even when RMS is well below it — that's the saturation mechanism.)
 
 **Mel mean per config (measured):**
 - v33 prepped data: ~0.37 (bimodal: clean+aug-quiet around 0.10, conditioned around 0.75)
 - v34 prepped data: 0.808 (unimodal+saturated; +18 aug variant clips at 1.0)
-- Device runtime: 0.754
+- Device runtime: 0.754 (mel mean of firmware-computed mel during music playback — not directly comparable to training mel mean since the audio level at the mic is unknown)
 
 v33's bimodal training distribution included device-like levels via the conditioned variant (compressor + whitening). It worked offline (val_peak_F1=0.690) and at degraded-but-functional on-device F1=0.570. v34 collapsed both modes into one centered too high, with the +18 dB aug pushing into saturation.
 
 ### v34b plan (2026-04-28)
 
-Single-axis change vs v33: `target_rms_db: -72 → -48`. Calibrates the gain-aug *peak* to device level instead of the *center*:
-- target_rms_db + 18 = -30 dBFS (device level) → target_rms_db = -48
-- Clean variant: -48 dBFS, mel mean ~0.20
-- Gain aug peak: -30 dBFS, mel mean ~0.50 (no saturation)
-- Conditioned variant: lands near device level via compressor+whitening (mel ~0.7-0.8)
+Single-axis change vs v33: `target_rms_db: -72 → -48`. Calibrates the gain-aug *peak* RMS to device level instead of the *center*:
+- target_rms_db + 18 = -30 dBFS RMS (target for the loudest aug variant) → target_rms_db = -48
+- **Predicted prep mel mean** (linear interpolation from measured v33=0.37 at -72 and v34=0.808 at -30): **~0.62** at -48
+- Per-variant prediction (rough; actual values are content-dependent):
+  - Clean variant: -48 dBFS RMS audio, mel mean ~0.40 (well below saturation; spectral content faithful)
+  - Gain aug +18 dB peak: -30 dBFS RMS audio, mel mean targets device-runtime distribution (measured 0.754). Whether this exact value is hit depends on the audio's spectral content — if training mel at -30 dBFS RMS lands somewhat lower, the conditioned variant's whitening still covers the device-loud regime.
+  - Conditioned variant: ~-42 dBFS RMS pre-compressor; +6 dB makeup + per-band whitening pull mel toward 1.0 in active bands. Stays in the 0.7-0.85 range.
 
 This sits between v33 (-72) and v34 (-30) and tests whether the calibration direction is right when saturation is avoided. If v34b also plateaus around 0.62, the calibration hypothesis is wrong and we revert to v33-as-deployed and approach from a different angle.
 
-**Falsifiable predictions for v34b on edm/:**
-- val_peak_F1 ≥ 0.66 (between v33's 0.69 and v34's 0.63)
-- on-device F1 ≥ v33's 0.570 (acceptance bar)
-- Activation distribution mean ≤ 0.40 (vs v34 at 0.45)
+**Falsifiable predictions for v34b:**
+- Offline val_peak_F1 ≥ 0.66 (between v33's 0.69 and v34's 0.63)
+- On-device F1 on edm/ ≥ v33's 0.570 (acceptance bar)
+- On-device NN activation mean ≤ 0.40 (vs v34's 0.45 — note: this is the model's *output* activation distribution measured during validation, not the training mel mean)
 
 ### Tool fixes landed 2026-04-23
 

--- a/ml-training/configs/base.yaml
+++ b/ml-training/configs/base.yaml
@@ -22,11 +22,28 @@ audio:
                             # isn't the bottleneck. Reverted: 60 dB gives better INT8 resolution
                             # (4.3 vs 3.2 levels/dB) and gain aug [-18,+18] covers device levels.
   frame_rate: 62.5          # 16000 / 256
-  target_rms_db: -72        # Normalize audio RMS to match device mel during music playback.
-  # Recalibrated April 14: device mel mean during music = 0.775, training at
-  # -63 dB produced mel mean = 0.924 (9 dB too loud). At -72 dB, clean training
-  # mel matches device level. Gain augmentation [-18, +18] covers the full range.
-  # Previous -63 dB meant the model saw device-realistic levels only ~10% of the time.
+  target_rms_db: -72        # Normalize audio RMS before mel computation.
+  #
+  # History — read carefully before changing:
+  #   - April 14: claimed -72 makes "training mel matches device level
+  #     mean=0.775". Re-measured 2026-04-27 (v33 50-mel × 8-kHz era):
+  #     training-clean mel mean at -72 is actually ~0.37, not ~0.78. The
+  #     April calibration was either taken on the conditioned variant
+  #     (compressor + per-band whitening pull mel toward 1.0) or made
+  #     against the older 26-mel × 4-kHz pipeline. Either way it does
+  #     not hold for the current 50-mel pipeline.
+  #   - 2026-04-27 (v34): shifted -72 → -30 to make training-clean mel
+  #     mean match device. Plateaued at val_peak_F1=0.627 (vs v33's
+  #     0.690). Cause: target_rms_db=-30 + gain_aug peak +18 dB = -12
+  #     dBFS effective, saturating bass mel bands at 1.0. Saturation
+  #     destroyed temporal contrast.
+  #   - 2026-04-28 (v34b in progress): -48. Calibrates the gain-aug PEAK
+  #     to device level (-30 dBFS) instead of the center, so the loudest
+  #     training variant matches device runtime without saturating.
+  #     Conditioned variant (compressor + whitening) lands near device
+  #     level via the augmentation path. Override per-config until v34b
+  #     result is known; do not change base default until then.
+  # See docs/ML_IMPROVEMENT_PLAN.md "v34 result + correction" for details.
   # AGC ceiling — must agree with firmware AdaptiveMic.h hwGainMaxSignal.
   # Gain sweep calibration shows SNR peaks at 25-35, degrades above 40.
   # prepare_dataset.py uses this to cap gain-aware noise augmentation.

--- a/ml-training/configs/conv1d_w16_onset_v34b_mel_only.yaml
+++ b/ml-training/configs/conv1d_w16_onset_v34b_mel_only.yaml
@@ -6,32 +6,42 @@
 # prepare_dataset.py (`for gain_db in [-18, -12, -6, 6, 12, 18]`).
 #
 # At target_rms_db=-30 + gain_aug=+18 dB, the loudest training variant
-# audio is -12 dBFS — louder than device runtime (~-15 dBFS effective)
-# and well into bass-mel-band saturation territory. Training mel mean
-# rose from v33's ~0.37 to v34's 0.808; samples in the +18 dB variant
-# saturated bands 0-7 at 1.0 (88% of frames in the device-mel measurement
-# already showed band-0 saturation; v34 training added more saturated
-# samples on top). Saturated mel destroys the temporal contrast that
-# peak-picking depends on. Frame F1 still climbed (saturation correlates
-# with onset-likely on average) but peak F1 plateaued.
+# audio is -12 dBFS RMS — louder than device runtime (~-15 dBFS RMS
+# effective) and well into bass-mel-band saturation territory once
+# instantaneous peaks are factored in. Training mel mean rose from v33's
+# ~0.37 to v34's 0.808; samples in the +18 dB variant saturated bands
+# 0-7 at 1.0 (88% of frames in the device-mel measurement already showed
+# band-0 saturation; v34 training added more saturated samples on top).
+# Saturated mel destroys the temporal contrast that peak-picking depends
+# on. Frame F1 still climbed (saturation correlates with onset-likely on
+# average) but peak F1 plateaued.
 #
 # Note on prior plan-doc claim "v33 dropped gain aug, v34 restored it":
 # WRONG. Both v33 and v34 ran with --augment (Makefile default), so
-# both used the same gain_aug [-18, +18]. The only substantive config
-# diff was target_rms_db (-72 → -30). Past experiments DID use this
-# gain aug consistently — what was new was the interaction with the
-# raised target_rms_db.
+# both used the same 6-step gain_aug set [-18, -12, -6, +6, +12, +18]
+# dB. The only substantive config diff was target_rms_db (-72 → -30).
+# Past experiments DID use this gain aug consistently — what was new
+# was the interaction with the raised target_rms_db.
 #
 # v34b fix: shift target_rms_db so the +18 dB gain aug peak lands at
-# device level (-30 dBFS), not 18 dB past it. Math:
+# device level (-30 dBFS RMS), not 18 dB past it. Math:
 #   target_rms_db + 18 = -30  →  target_rms_db = -48
-# At -48 dBFS:
-#   - Clean variant: -48 dBFS effective, mel mean ~0.20
-#   - Gain aug peak (+18 dB): -30 dBFS effective, mel mean ~0.50 (no sat)
+#
+# Predicted prep mel mean (linear interpolation from measured
+# v33 prep mean=0.37 at -72 and v34 prep mean=0.808 at -30):
+# at -48, composite prep mel mean ≈ 0.62. Per-variant prediction:
+#   - Clean variant: -48 dBFS RMS audio, mel mean ~0.40 (well below
+#     saturation; clean variant carries spectral content faithfully)
+#   - Gain aug +18 dB peak: -30 dBFS RMS audio, mel mean targets the
+#     device runtime level (measured 0.754) — this is the design intent.
+#     Whether training mel at -30 dBFS RMS produces 0.754 depends on the
+#     audio's spectral content; if it lands lower, the gap is closed by
+#     the conditioned variant's whitening rather than this path.
 #   - Conditioned variant: ~-42 dBFS pre-compressor; +6 dB makeup gain
-#     and per-band whitening pull mel toward device level (mel ~0.7-0.8)
-#     — conditioned path is the primary device-level training signal
-#   - Conditioned + gain_aug+18: louder, but whitening normalizes
+#     and per-band whitening pull mel toward 1.0 in active bands. Stays
+#     in the 0.7-0.85 range that matches device runtime distribution.
+#   - Conditioned + gain_aug+18: still saturating in bass bands but a
+#     much smaller fraction of training data than v34's regime.
 #
 # This sits between v33's -72 and v34's -30. Tests the calibration
 # direction without re-introducing v34's saturation. Single-axis change.
@@ -78,7 +88,9 @@ features:
 
 loss:
   type: "bce"
-  pos_weight: 0
+  # NOTE: pos_weight is intentionally NOT here — train.py reads pos_weight
+  # exclusively from cfg["training"] (see train.py:657, 764). Listing it
+  # twice would be a configuration trap. Per PR 134 review.
 
 training:
   mixup: false

--- a/ml-training/configs/conv1d_w16_onset_v34b_mel_only.yaml
+++ b/ml-training/configs/conv1d_w16_onset_v34b_mel_only.yaml
@@ -1,0 +1,102 @@
+# Conv1D W16 v34b — single-axis recalibration after v34 failure
+#
+# v34 used target_rms_db=-30 to match measured device mel mean (0.754).
+# Result: plateaued at val_peak_F1=0.627 vs v33's 0.690. Root cause is
+# the interaction between target_rms_db and the gain augmentation in
+# prepare_dataset.py (`for gain_db in [-18, -12, -6, 6, 12, 18]`).
+#
+# At target_rms_db=-30 + gain_aug=+18 dB, the loudest training variant
+# audio is -12 dBFS — louder than device runtime (~-15 dBFS effective)
+# and well into bass-mel-band saturation territory. Training mel mean
+# rose from v33's ~0.37 to v34's 0.808; samples in the +18 dB variant
+# saturated bands 0-7 at 1.0 (88% of frames in the device-mel measurement
+# already showed band-0 saturation; v34 training added more saturated
+# samples on top). Saturated mel destroys the temporal contrast that
+# peak-picking depends on. Frame F1 still climbed (saturation correlates
+# with onset-likely on average) but peak F1 plateaued.
+#
+# Note on prior plan-doc claim "v33 dropped gain aug, v34 restored it":
+# WRONG. Both v33 and v34 ran with --augment (Makefile default), so
+# both used the same gain_aug [-18, +18]. The only substantive config
+# diff was target_rms_db (-72 → -30). Past experiments DID use this
+# gain aug consistently — what was new was the interaction with the
+# raised target_rms_db.
+#
+# v34b fix: shift target_rms_db so the +18 dB gain aug peak lands at
+# device level (-30 dBFS), not 18 dB past it. Math:
+#   target_rms_db + 18 = -30  →  target_rms_db = -48
+# At -48 dBFS:
+#   - Clean variant: -48 dBFS effective, mel mean ~0.20
+#   - Gain aug peak (+18 dB): -30 dBFS effective, mel mean ~0.50 (no sat)
+#   - Conditioned variant: ~-42 dBFS pre-compressor; +6 dB makeup gain
+#     and per-band whitening pull mel toward device level (mel ~0.7-0.8)
+#     — conditioned path is the primary device-level training signal
+#   - Conditioned + gain_aug+18: louder, but whitening normalizes
+#
+# This sits between v33's -72 and v34's -30. Tests the calibration
+# direction without re-introducing v34's saturation. Single-axis change.
+#
+# Falsifiable predictions:
+#   - val_peak_F1 ≥ 0.66 (between v33's 0.69 and v34's 0.63)
+#   - frame F1 trajectory similar to v33's epochs 1-14
+#   - on-device F1 on edm/ ≥ v33's 0.570 (acceptance bar)
+#   - tier-1 tracks all hold their current F1
+#
+# Negative-result triggers:
+#   - val_peak_F1 ≤ 0.62: target_rms_db is not the right knob; revert to v33
+#     and approach from a different angle (model capacity? loss function?)
+#   - on-device F1 same as v33 b153 (0.570): the bimodal training
+#     distribution argument was wrong — calibration alone won't move it.
+
+model:
+  type: "frame_conv1d"
+  channels: [32, 32]
+  kernel_sizes: [5, 5]
+  window_frames: 16
+  dropout: 0.1
+  freq_pos_encoding: false
+  num_output_channels: 0
+
+labels:
+  target_type: "binary"
+  labels_type: "kick_weighted"
+  kick_weighted_dir: "/mnt/storage/blinky-ml-data/labels/kick_weighted_drums"
+  neighbor_weight: 0.25
+  label_shift_frames: 1
+  hard_binary_threshold: 0.1
+
+audio:
+  n_mels: 50
+  fmin: 30
+  fmax: 8000
+  # The single change vs v33. See header comment for derivation.
+  target_rms_db: -48
+
+features:
+  use_delta: false
+  use_pcen: false
+
+loss:
+  type: "bce"
+  pos_weight: 0
+
+training:
+  mixup: false
+  epochs: 60
+  patience: 15
+  pos_weight: 0
+  early_stopping_metric: "val_peak_f1"
+
+augmentation:
+  freq_mixstyle:
+    enabled: true
+    p: 0.5
+    alpha: 0.6
+
+data:
+  processed_dir: "/mnt/storage/blinky-ml-data/processed_v34b"
+
+export:
+  output_header: "../blinky-things/audio/frame_onset_model_data_v34b_mel_only.h"
+  c_array_name: "frame_onset_model_data"
+  max_model_size_kb: 27

--- a/ml-training/scripts/prepare_dataset.py
+++ b/ml-training/scripts/prepare_dataset.py
@@ -1720,7 +1720,14 @@ def main():
     chunk_frames = cfg["training"]["chunk_frames"]
     chunk_stride = cfg["training"]["chunk_stride"]
     n_mels = cfg["audio"]["n_mels"]
-    SHARD_BATCH = 500  # files per shard (limits RAM to ~3 GB)
+    # files per shard. Limits RAM growth from accumulated mel arrays + futures.
+    # Empirical: at 30 mel × 6 gain variants (v32 era), 500 files held ~3 GB.
+    # At 50 mel × restored gain aug (v34, 2026-04-27), 500 files OOM'd a 62 GB
+    # box at file 5500 (~58 GB anon-rss). The 15× growth over the original
+    # estimate likely comes from teacher activations + augmentation stacking
+    # (clean / conditioned / stretched / gain-augmented variants compose).
+    # Lowering to 150 keeps peak in-flight ~5-7 GB even at 50 mel.
+    SHARD_BATCH = 150
 
     # Thread pool for audio prefetching and parallel chunking.
     # librosa.load and numpy operations release the GIL, so threads give


### PR DESCRIPTION
v34 plateaued at val_peak_F1=0.627 (vs v33's 0.690). Deeper investigation revealed two errors in the v34 plan:

1. The plan claimed "v33 dropped gain aug, v34 restored it" — wrong. Both v33 and v34 ran with --augment, both applied the same hardcoded gain_aug [-18,-12,-6,+6,+12,+18] dB. Only substantive config diff was target_rms_db (-72 → -30).

2. The fix calculation didn't account for gain_aug peak interaction. At v34's target_rms_db=-30 + gain_aug=+18 dB, the loudest training variant lands at -12 dBFS — louder than device runtime (~-15 dBFS) and saturating bass mel bands (88% of frames in device-mel measurement already showed band-0 saturation; v34 added more saturated samples on top via the +18 dB aug). Saturated mel destroys the temporal contrast peak-picking depends on. Frame F1 still climbed (saturation correlates with onset-likely on average) but peak F1 plateaued — exactly what we observed.

v34b math: target_rms_db + 18 = -30 (device level) → target_rms_db = -48. At -48 dBFS:
  - Clean variant: -48 dBFS effective, mel mean ~0.20
  - Gain aug peak: -30 dBFS, mel mean ~0.50 (no saturation)
  - Conditioned variant: ~-42 pre-comp, +6 makeup + per-band whitening pulls mel mean toward device level (~0.7-0.8) — primary device- level training signal

Sits between v33 (-72) and v34 (-30). Single-axis change vs v33.

Falsifiable predictions:
- val_peak_F1 >= 0.66 (between v33's 0.69 and v34's 0.63)
- on-device F1 on edm/ >= v33's 0.570
- training mel mean ~0.45-0.55 (vs v34's 0.808)

Negative-result triggers:
- val_peak_F1 <= 0.62: target_rms_db is not the right knob; revert to v33
- on-device F1 same as v33 b153: bimodal training argument was wrong

Plan doc updated with v34 result + correction + v34b motivation. Same architecture, labels, n_mels, fmin/fmax, augmentation as v33.